### PR TITLE
Move native functions from toolkit to sample

### DIFF
--- a/samples/CustomKey/.gitignore
+++ b/samples/CustomKey/.gitignore
@@ -1,0 +1,4 @@
+/.apt_generated/
+/impl/java/gensrc
+/com.ibm.streamsx.hbase.sample/native.function/
+/data

--- a/samples/CustomKey/.settings/org.eclipse.jdt.apt.core.prefs
+++ b/samples/CustomKey/.settings/org.eclipse.jdt.apt.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.apt.aptEnabled=true
+org.eclipse.jdt.apt.genSrcDir=impl/java/gensrc/com/ibm/streamsx/hbase/sample
+org.eclipse.jdt.apt.reconcileEnabled=false

--- a/samples/CustomKey/com.ibm.streamsx.hbase.sample/CustomKey.spl
+++ b/samples/CustomKey/com.ibm.streamsx.hbase.sample/CustomKey.spl
@@ -70,7 +70,7 @@ composite CustomKey
 				// The key is of type blob, but in order to call get long, we have to cast it to type
 				// list<uint8>.  The second argument is the index where to start looking for the long.
 				// This must be unsigned for the function to work. 
-				time = com.ibm.streamsx.hbase::getLong((list<uint8>) key, 0u),
+				time = com.ibm.streamsx.hbase.sample::getLong((list<uint8>) key, 0u),
 
 				// Now we extract the string.  We again need ot case the key to list<uint8>.
 				// Get string requires the starting point of the string (in this case, just after
@@ -78,7 +78,7 @@ composite CustomKey
 				// length, you can use that, but here since we know the string is the last
 				// thing in the blob, we'll calcuate the length from the blob size and the starting
 				// point.
-				location = com.ibm.streamsx.hbase::getString((list<uint8>) key, 8u,(uint32)
+				location = com.ibm.streamsx.hbase.sample::getString((list<uint8>) key, 8u,(uint32)
 					size(key) - 8u) ;
 		}
 

--- a/samples/CustomKey/impl/java/src/com/ibm/streamsx/hbase/sample/HelperFunctions.java
+++ b/samples/CustomKey/impl/java/src/com/ibm/streamsx/hbase/sample/HelperFunctions.java
@@ -1,4 +1,4 @@
-package com.ibm.streamsx.hbase;
+package com.ibm.streamsx.hbase.sample;
 
 import java.nio.ByteBuffer;
 import java.util.logging.Level;
@@ -8,20 +8,22 @@ import java.util.logging.Logger;
 
 
 import com.ibm.streams.function.model.Function;
-
 public class HelperFunctions {
-	public static final String NAMESPACE="com.ibm.streamsx.hbase";
+	public static final String NAMESPACE="com.ibm.streamsx.hbase.sample";
 	public static final Logger trace = Logger.getLogger(HelperFunctions.class.getCanonicalName());
 	//= LogManager.getLogger(HelperFunctions.class.getCanonicalName());
 	
-	@Function(namespace=NAMESPACE)
+	// The sample application uses the makeKey function to make a key,
+	// but an application could use a combination of the appendLong and appendString
+	// functions instead. 
+	@Function(namespace=NAMESPACE,description="Append the long, in bytes, to the current blob and return the resulting blob.  The original blob is unchanged.")
 	public static byte[] appendLong(byte[] currentBlob,long toAppend ) {
 		ByteBuffer buffer = ByteBuffer.allocate(currentBlob.length + Long.SIZE/Byte.SIZE);
 		buffer.put(currentBlob);
 		buffer.putLong(toAppend);
 		return buffer.array();
 	}
-	@Function
+	@Function(namespace=NAMESPACE,description="Get the type representation of the string toAppend (using the default character set), and append it to the blob, and return the result.  The original blob is unchanged.")
 	public static byte[] appendString(byte[] currentBlob, String toAppend) {
 		byte[] stringBytes = toAppend.getBytes();
 		byte[] toReturn = new byte[stringBytes.length+ currentBlob.length];
@@ -33,12 +35,12 @@ public class HelperFunctions {
 		}
 		return toReturn;
 	}
-	@Function
+	@Function(namespace=NAMESPACE,description="Starting at index, return the long represented by bytes in the blob from index to index+7")
 	public static long getLong(byte[] currentBlob,int index) {
 		ByteBuffer buffer = ByteBuffer.wrap(currentBlob);
 		return buffer.getLong(index);
 	}
-	@Function
+	@Function(namespace=NAMESPACE,description="Starting at index, return the string represented by the bytes index to index+length-1 in the blob.  Assumes the default character set.")
 	public static String getString(byte[] currentBlob, int offset, int length) {
 		trace.log(Level.INFO,"Entering getString, currentBlob size {0}, index {1}, length {2}",new Object[] {currentBlob.length,offset,length});
 		byte [] stringBytes = new byte[length];

--- a/samples/CustomKey/info.xml
+++ b/samples/CustomKey/info.xml
@@ -4,12 +4,12 @@
     <info:name>CustomKey</info:name>
     <info:description>Demonstrate how to use a java native function to generate a custom key.</info:description>
     <info:version>1.0.0</info:version>
-    <info:requiredProductVersion>3.2.2.0</info:requiredProductVersion>
+    <info:requiredProductVersion>3.2.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies>
     <info:toolkit>
       <common:name>com.ibm.streamsx.hbase</common:name>
-      <common:version>2.0.0</common:version>
+      <common:version>1.2.0</common:version>
     </info:toolkit>
   </info:dependencies>
 </info:toolkitInfoModel>


### PR DESCRIPTION
As I'm not yet sure exactly how key-building functions should be supported, I moved them from the toolkit proper to a sample.  