### PR TITLE
Include jackson jars in opt/downloaded and fix delete sample

### DIFF
--- a/com.ibm.streamsx.hbase/build.xml
+++ b/com.ibm.streamsx.hbase/build.xml
@@ -104,7 +104,7 @@
 		<echo message="copying only the necessary files"/>
 		<copy todir="${ext.downloads.dir}" verbose="true">
 		  <fileset dir="${ext.downloads.dir.all}" 
-			   includes="commons-codec*,hadoop-auth*,hbase-common*,commons-configuration*,hadoop-common*,hbase-protocol*,commons-logging*,hbase-client*,htrace-core*"/> 
+			   includes="commons-codec*,hadoop-auth*,hbase-common*,commons-configuration*,hadoop-common*,hbase-protocol*,commons-logging*,hbase-client*,htrace-core*,jackson-mapper-asl-*,jackson-core-asl*"/> 
 		  </copy>
 	</target>
 

--- a/samples/DeleteSample/Makefile
+++ b/samples/DeleteSample/Makefile
@@ -23,7 +23,7 @@ data:
 	mkdir data
 
 standalone_delete: data
-	$(SPLC) $(SPLC_FLAGS) -T -M $(SPL_MAIN_COMPOSITE_DELETE) $(SPL_CMD_ARGS) --output-dir output_plain
+	$(SPLC) $(SPLC_FLAGS) -T -M $(SPL_MAIN_COMPOSITE_DELETE) $(SPL_CMD_ARGS) --output-dir output_delete
 
 standalone_check: data
 	$(SPLC) $(SPLC_FLAGS) -T -M $(SPL_MAIN_COMPOSITE_CHECK) $(SPL_CMD_ARGS) --output-dir output_check


### PR DESCRIPTION
DeleteSample had a target `standalone_delete` which compiled to output directory `output_plain`; change the output directory suffix to `_delete` to match the target suffix.

Added: `jackson-mapper-asl` and `jackson-core-asl` to the list of jars copied to opt/downloaded.