### PR TITLE
set HBase toolkit to a location that exists

### DIFF
--- a/samples/GetRecord/Makefile
+++ b/samples/GetRecord/Makefile
@@ -6,8 +6,12 @@
 
 .PHONY: all clean 
 
+TOOLKIT_NAME=com.ibm.streamsx.hbase
 # Fill in STREAMS_HBASE_TOOLKIT location here.
-STREAMS_HBASE_TOOLKIT ?= ../../com.ibm.streamsx.hbase
+STREAMS_HBASE_TOOLKIT ?= $(shell  ([ -e ../../$(TOOLKIT_NAME) ] && echo ../../$(TOOLKIT_NAME)) ||\
+	         ([ -e "../com.ibm.streamsx.hbase" ] && echo ../$(TOOLKIT_NAME)) ||\
+	                 echo $(STREAMS_INSTALL)/toolkits/$(TOOLKIT_NAME))
+
 
 SPLC_FLAGS ?= -a --data-directory data 
 SPLC = $(STREAMS_INSTALL)/bin/sc

--- a/samples/GetSample/Makefile
+++ b/samples/GetSample/Makefile
@@ -6,9 +6,12 @@
 
 .PHONY: all clean 
 
-# Fill in STREAMS_HBASE_TOOLKIT location here.
-STREAMS_HBASE_TOOLKIT ?= ../../com.ibm.streamsx.hbase
 
+TOOLKIT_NAME=com.ibm.streamsx.hbase
+# Fill in STREAMS_HBASE_TOOLKIT location here.
+STREAMS_HBASE_TOOLKIT ?= $(shell  ([ -e ../../$(TOOLKIT_NAME) ] && echo ../../$(TOOLKIT_NAME)) ||\
+	                  ([ -e "../com.ibm.streamsx.hbase" ] && echo ../$(TOOLKIT_NAME)) ||\
+	                                           echo $(STREAMS_INSTALL)/toolkits/$(TOOLKIT_NAME))
 SPLC_FLAGS ?= -a --data-directory data 
 SPLC = $(STREAMS_INSTALL)/bin/sc
 

--- a/samples/PutRecord/Makefile
+++ b/samples/PutRecord/Makefile
@@ -6,8 +6,11 @@
 
 .PHONY: all clean 
 
-# Fill in STREAMS_HBASE_TOOLKIT location here.
-STREAMS_HBASE_TOOLKIT ?= ../../com.ibm.streamsx.hbase
+TOOLKIT_NAME=com.ibm.streamsx.hbase
+STREAMS_HBASE_TOOLKIT ?= $(shell  ([ -e ../../$(TOOLKIT_NAME) ] && echo ../../$(TOOLKIT_NAME)) ||\
+						          ([ -e "../com.ibm.streamsx.hbase" ] && echo ../$(TOOLKIT_NAME)) ||\
+									echo $(STREAMS_INSTALL)/toolkits/$(TOOLKIT_NAME))
+
 
 SPLC_FLAGS ?= -a --data-directory data 
 SPLC = $(STREAMS_INSTALL)/bin/sc

--- a/samples/PutSample/Makefile
+++ b/samples/PutSample/Makefile
@@ -6,8 +6,10 @@
 
 .PHONY: all clean 
 
-# Fill in STREAMS_HBASE_TOOLKIT location here.
-STREAMS_HBASE_TOOLKIT ?= ../../com.ibm.streamsx.hbase
+TOOLKIT_NAME=com.ibm.streamsx.hbase
+STREAMS_HBASE_TOOLKIT ?= $(shell  ([ -e ../../$(TOOLKIT_NAME) ] && echo ../../$(TOOLKIT_NAME)) ||\
+			                      ([ -e "../com.ibm.streamsx.hbase" ] && echo ../$(TOOLKIT_NAME)) ||\
+			                       echo $(STREAMS_INSTALL)/toolkits/$(TOOLKIT_NAME))
 
 SPLC_FLAGS ?= -a --data-directory data 
 SPLC = $(STREAMS_INSTALL)/bin/sc


### PR DESCRIPTION
In the Makefiles for the samples, be more flexible about setting the toolkit location.  These script changes ensure that what ever is used for the toolkit location actually has a toolkit.  This means the Makefile should work when used from a git clone or when imported into eclipse, or when in a Streams install.