### PR TITLE
HBASEPut: disabled autoflush (issue #80)

### DIFF
--- a/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEPut.java
+++ b/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEPut.java
@@ -221,7 +221,7 @@ public class HBASEPut extends HBASEPutDelete {
 			// It should be impossible to get here.
 			throw new Exception("Unsupported Put type");
 		}
-		HTableInterface myTable = connection.getTable(tableNameBytes);
+		
 		if (checkAttr != null) {
 			Tuple checkTuple = tuple.getTuple(checkAttrIndex);
 
@@ -252,7 +252,6 @@ public class HBASEPut extends HBASEPutDelete {
 		// Checks to see if an output tuple is necessary, and if so,
 		// submits it.
 		submitOutputTuple(tuple, success);
-		myTable.close();
 	}
 
 	/**
@@ -267,7 +266,6 @@ public class HBASEPut extends HBASEPutDelete {
 					myTable.put(putList);
 				}
 			}
-			myTable.close();
 		}
 	}
 


### PR DESCRIPTION
For HBASE client API version < 0.99 it's possible to improve performance with the following operations:
 - move the HTableInterface creation to the initialization phase of the operator, instead of creating/closing the HTable for every tuple/batchSize, In the fix we are implementing, we moved the myTable object to the initialize method in the HBASEOperator abstract class.
 - consider disabling autoFlush (refer to http://hbase.apache.org/0.94/book/perf.writing.html): setAutoFlush(bool, bool) is a method of HTableInterface, we applied right after the myTable creation