### PR TITLE
thread safety for put operator when autoflush is disabled

### DIFF
--- a/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEDelete.java
+++ b/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEDelete.java
@@ -61,7 +61,7 @@ import com.ibm.streams.operator.state.ConsistentRegionContext;
 		+ "When that attribute is specified, deletes are conditional on the state of the table, and so may either succeed or fail. "
 		+ "This output port allows the SPL developer to determine whether the delete succeede or failed.  "
 		+ "For each input tuple, an output tuple is generated. "
-		+ "The attribute named by "+HBASEPutDelete.SUCCESS_PARAM+" is set to true when the delete succeded, and false otherwise"
+		+ "The attribute named by "+HBASEPutDelete.SUCCESS_PARAM+" is set to true when the delete succeded, and false otherwise.  "
 		+ "The other attributes are copied from the input tuple.", cardinality = 1, optional = true, windowPunctuationOutputMode = WindowPunctuationOutputMode.Preserving) })
 @Icons(location32 = "impl/java/icons/HBASEDelete_32.gif", location16 = "impl/java/icons/HBASEDelete_16.gif")
 public class HBASEDelete extends HBASEPutDelete {
@@ -91,6 +91,10 @@ public class HBASEDelete extends HBASEPutDelete {
 		deleteAll = _delete;
 	}
 
+	@Parameter(name = BATCHSIZE_NAME, optional = true, description = "Maximum number of Deletes to buffer before sending to HBase.  Larger numbers are more efficient, but increase the risk of lost changes on operator crash.  In a consistent region, a drain flushes the buffer to HBase.")
+	public void setBatchSize(int _size) {
+		batchSize = _size;
+	}
 	/**
 	 * deleteAll only has an effect when a single cell is being deleted, so
 	 * let's make sure no one is misusing it. To do this, we make sure a
@@ -242,6 +246,7 @@ public class HBASEDelete extends HBASEPutDelete {
 						myTable.delete(deleteList);
 					}
 				}
+				myTable.close();
 			}
 		}
 	}
@@ -258,6 +263,5 @@ public class HBASEDelete extends HBASEPutDelete {
 				deleteList.clear();
 			}
 		}
-
 	}
 }

--- a/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEOperator.java
+++ b/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEOperator.java
@@ -83,7 +83,6 @@ public abstract class HBASEOperator extends AbstractOperator {
 	static final String VALID_TYPE_STRING="rstring, ustring, blob, or int64";
 	static final int BYTES_IN_LONG = Long.SIZE/Byte.SIZE;
 	
-	HTableInterface myTable = null;
 	
     @Parameter(name=HBASE_SITE_PARAM_NAME, optional=true,description="The hbase-site.xml file.  This is the recommended way to specify the HBASE configuration.  If not specified, then `HBASE_HOME` must be set when the operator runs, and it will use `$HBASE_SITE/conf/hbase-site.xml`")
 	public void setHbaseSite(String name) {
@@ -270,13 +269,6 @@ public abstract class HBASEOperator extends AbstractOperator {
 	connection = HConnectionManager.createConnection(conf);
 	tableNameBytes = tableName.getBytes(charset);
 	
-	myTable = connection.getTable(tableNameBytes);
-
-    	if (null == myTable) {
-    		Logger.getLogger(this.getClass()).error("Cannot access table, failing.");
-    		throw new Exception("Cannot access table.  Check configuration");
-    	}
-    	myTable.setAutoFlush(false, true);
 	}
 	
 	/**
@@ -300,9 +292,6 @@ public abstract class HBASEOperator extends AbstractOperator {
    @Override
    public synchronized void shutdown() throws Exception {
        OperatorContext context = getOperatorContext();
-       if (myTable != null) {
-    	   myTable.close();
-       }
        Logger.getLogger(this.getClass()).trace("Operator " + context.getName() + " shutting down in PE: " + context.getPE().getPEId() + " in Job: " + context.getPE().getJobId() );
        if (connection != null && !connection.isClosed()) {
     	   connection.close();

--- a/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEPut.java
+++ b/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEPut.java
@@ -329,9 +329,11 @@ public class HBASEPut extends HBASEPutDelete {
 	
 	@Override
 	public void shutdown() throws Exception {
+		flushBuffer();
 		if (cachedTable != null) {
 			cachedTable.close();
 		}
+		super.shutdown();
 			
 	}
 	

--- a/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEPut.java
+++ b/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEPut.java
@@ -342,6 +342,7 @@ public class HBASEPut extends HBASEPutDelete {
 	protected void safeFlush() throws IOException {
 		if (connection != null && !connection.isClosed()) {
 			synchronized (tableLock) {
+				logger.debug("Calling hbase internal flush commits");
 				cachedTable.flushCommits();
 			}
 		}

--- a/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEPutDelete.java
+++ b/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEPutDelete.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.log4j.Logger;
 
 import com.ibm.streams.operator.Attribute;
@@ -59,17 +60,13 @@ public abstract class HBASEPutDelete extends HBASEOperatorWithInput implements
 	private String successAttrName = null;
 	private int successAttrIndex = -1;
 	StreamingOutput<OutputTuple> outStream = null;
-
+	
 	@Parameter(name = SUCCESS_PARAM, optional = true, description = "Attribute on the output port to be set to true if the check passes and the action is successful")
 	public void setSuccessAttr(String name) {
 		successAttrName = name;
 	}
 
-	@Parameter(name = BATCHSIZE_NAME, optional = true, description = "Maximum number of Puts or Deletes to buffer before sending to HBase.  Larger numbers are more efficient, but increase the risk of lost changes on operator crash.  In a consistent region, a drain flushes the buffer to HBase.")
-	public void setBatchSize(int _size) {
-		batchSize = _size;
-	}
-
+	
 	@Parameter(name = CHECK_ATTR_PARAM, optional = true, description = "Name of the attribute specifying the tuple to check for before applying the Put or Delete.  The type of the attribute is tuple with attributes columnFamily and columnQualifier, or a tuple with attributes columnFamily, columnQualifier, and value.   In the first case, the Put or Delete will be allowed to proceed only when there is no entry for the row, columnFamily, columnQualifer combination.  When the the type of the attribute given by "+CHECK_ATTR_PARAM+" contains an attribute `value`, the Put or Delete operation will only succeed when the entry specified the row, columnFamily, and columnQualifier has the given value.")
 
 	public void setCheckAttr(String name) {
@@ -110,7 +107,9 @@ public abstract class HBASEPutDelete extends HBASEOperatorWithInput implements
 		successRequiresOutput(checker);
 		checker.checkDependentParameters(SUCCESS_PARAM, CHECK_ATTR_PARAM);
 		checkConsistentRegionSource(checker, operatorName);
-
+		if (!checker.checkExcludedParameters(CHECK_ATTR_PARAM, BATCHSIZE_NAME)){
+			checker.setInvalidContext("The " + CHECK_ATTR_PARAM + " parameter cannot be used with the " + BATCHSIZE_NAME + "  parameter", new Object[0]);
+		}
 	}
 
 	protected void establishCheckAttrMatching(Attribute checkAttr)
@@ -163,11 +162,14 @@ public abstract class HBASEPutDelete extends HBASEOperatorWithInput implements
 			throws Exception {
 		// Must call super.initialize(context) to correctly setup an operator.
 		super.initialize(context);
+		
+		
+		HTableInterface table = connection.getTable(tableNameBytes);
 
-		if (batchSize > 0 && checkAttr != null) {
-			// TODO make this proper context check!
-			throw new Exception("Cannot use checkAttr with batchSize > 0");
-		}
+    	if (null == table) {
+    		Logger.getLogger(this.getClass()).error("Cannot access table, failing.");
+    		throw new Exception("Cannot access table.  Check configuration");
+    	}
 
 		StreamingInput<Tuple> input = context.getStreamingInputs().get(0);
 		StreamSchema inputSchema = input.getStreamSchema();
@@ -206,6 +208,7 @@ public abstract class HBASEPutDelete extends HBASEOperatorWithInput implements
 			}
 			successAttrIndex = attr.getIndex();
 		}
+		table.close();
 		context.registerStateHandler(this);
 	}
 
@@ -217,7 +220,7 @@ public abstract class HBASEPutDelete extends HBASEOperatorWithInput implements
 	/**
 	 * Clear the buffer of pending changes. Called by reset.
 	 */
-	abstract protected void clearBuffer();
+	abstract protected void clearBuffer() throws Exception;
 
 	/**
 	 * Shutdown this operator.
@@ -228,7 +231,7 @@ public abstract class HBASEPutDelete extends HBASEOperatorWithInput implements
 	@Override
 	public void shutdown() throws Exception {
 		flushBuffer();
-		super.shutdown();
+	  super.shutdown();
 	}
 
 	@Override


### PR DESCRIPTION
When autoflush is disabled, we cannot close the table after every tuple is processed because this would force a flush to HBASE. So we have to cache the reference to the HTable, and synchronize access.