### PR TITLE
Added a FuzzyRow filter to partially solve issue #32

### DIFF
--- a/com.ibm.streamsx.hbase/.classpath
+++ b/com.ibm.streamsx.hbase/.classpath
@@ -3,13 +3,78 @@
 	<classpathentry kind="src" output="impl/java/bin" path="impl/java/src"/>
 	<classpathentry exported="true" kind="con" path="com.ibm.streams.java/com.ibm.streams.operator"/>
 	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="src" path=".apt_generated">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="opt/downloaded/activation-1.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/aopalliance-1.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/asm-3.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/avro-1.7.4.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-beanutils-1.7.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-beanutils-core-1.8.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-cli-1.2.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-codec-1.4.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-collections-3.2.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-compress-1.4.1.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/commons-configuration-1.6.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-digester-1.8.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-el-1.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-httpclient-3.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-io-2.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-lang-2.5.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/commons-logging-1.1.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-math-2.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/commons-net-3.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/findbugs-annotations-1.3.9-1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/guava-11.0.2.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/guice-3.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/guice-servlet-3.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/hadoop-annotations-2.2.0.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/hadoop-auth-2.2.0.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/hadoop-common-2.2.0.jar"/>
-	<classpathentry kind="lib" path="opt/downloaded/htrace-core-2.04.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/hadoop-mapreduce-client-core-2.2.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/hadoop-yarn-api-2.2.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/hadoop-yarn-common-2.2.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/hamcrest-core-1.3.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/hbase-client-0.98.4-hadoop2.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/hbase-common-0.98.4-hadoop2.jar"/>
 	<classpathentry kind="lib" path="opt/downloaded/hbase-protocol-0.98.4-hadoop2.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/htrace-core-2.04.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jackson-core-asl-1.8.8.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jackson-jaxrs-1.8.3.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jackson-mapper-asl-1.8.8.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jackson-xc-1.8.3.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jasper-compiler-5.5.23.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jasper-runtime-5.5.23.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/javax.inject-1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jaxb-api-2.2.2.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jaxb-impl-2.2.3-1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jdk.tools-1.6.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jersey-core-1.9.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jersey-guice-1.9.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jersey-json-1.9.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jersey-server-1.9.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jets3t-0.6.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jettison-1.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jetty-6.1.26.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jetty-util-6.1.26.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jsch-0.1.42.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jsp-api-2.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/jsr305-1.3.9.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/junit-4.11.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/log4j-1.2.17.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/netty-3.6.6.Final.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/paranamer-2.3.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/protobuf-java-2.5.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/servlet-api-2.5.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/slf4j-api-1.7.5.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/slf4j-log4j12-1.7.5.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/snappy-java-1.0.4.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/stax-api-1.0.1.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/xmlenc-0.52.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/xz-1.0.jar"/>
+	<classpathentry kind="lib" path="opt/downloaded/zookeeper-3.4.5.jar"/>
 	<classpathentry kind="output" path="impl/java/bin"/>
 </classpath>

--- a/com.ibm.streamsx.hbase/README
+++ b/com.ibm.streamsx.hbase/README
@@ -2,7 +2,7 @@ This toolkit is for interacting with Apache HBASE.  It assumes Apache HBASE
 is already installed and running.
 
 To use the operators, you must set HADOOP_HOME and HBASE_HOME in your
-environment before compiling.  
+environment before compiling or use the hbaseSite parameter. 
 
 This toolkit provides Streams operators to work with the HBASE API,
 so the operators are named after the HBASE API calls.  There is another
@@ -27,4 +27,4 @@ the input tuple.  The increment value can be in the tuple, and operator paramete
 or unspecified.  If unspecified, the increment value uses the default. 
 HBASEScan: Scan a table (ie, get all tuples in the table).  The output can be limited to
 specific column families or to a column family, column qualifier pair.  A start row
-and an end row may also be specified.   
+and an end row may also be specified. Optionally a row prefix, or fuzzy row matching can be used.  

--- a/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEOperator.java
+++ b/com.ibm.streamsx.hbase/impl/java/src/com/ibm/streamsx/hbase/HBASEOperator.java
@@ -36,7 +36,7 @@ import com.ibm.streams.operator.types.Blob;
  * @author hildrum
  *
  */
-@Libraries({"@HBASE_HOME@/lib/*", "@HBASE_HOME@/*"})
+@Libraries({"@HBASE_HOME@/lib/*", "@HBASE_HOME@/*", "opt/downloaded/*", "impl/lib/*"})
 public abstract class HBASEOperator extends AbstractOperator {
 	public static final String DOC_BLANKLINE = "\\n\\n";
     static final String HBASE_SITE_PARAM_NAME="hbaseSite";

--- a/com.ibm.streamsx.hbase/info.xml
+++ b/com.ibm.streamsx.hbase/info.xml
@@ -111,11 +111,11 @@ Alternatively, you can fully qualify the operators that are provided by toolkit 
 7. Start the InfoSphere Streams instance. Remember to set **HBASE_HOME** and **HADOOP_HOME** (for BigInsights) as described above as application environment variable(s) on the instance. This can be done using the Streams Console or the `streamtool` utility.
 8. Run the application. You can submit the application as a job by using the **streamtool submitjob** command or by using Streams Studio. 
 </info:description>
-    <info:version>2.1.0</info:version>
+    <info:version>2.1.1</info:version>
     <info:requiredProductVersion>4.0.0.0</info:requiredProductVersion>
   </info:identity>
   <info:dependencies/>
   <info:sabFiles>
-    <info:exclude path="opt/downloaded"/>
+    <info:exclude path="opt/downloaded/"/>
   </info:sabFiles>
 </info:toolkitInfoModel>


### PR DESCRIPTION
Added a fuzzyRowString parameter to HBASEScan to allow for selections by a fuzzy row.   This should be much more reasonable on the network for situations where a fuzzy row is needed (e.g. a key with random prefixes used to load-balance) rather than pulling everything back and then filtering.   Tested with HBASE 1.2.2